### PR TITLE
Spotify リスニングヒストリー監視システムの実装

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(find:*)",
+      "WebFetch(domain:github.com)",
+      "Bash(python -m pytest test_spotify_monitor.py -v)",
+      "Bash(pipenv run python -m pytest:*)",
+      "Bash(pipenv install:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)"
+    ],
+    "deny": []
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## プロジェクト概要
+
+Spotify Web APIラッパーサービス。FastAPIベースのPython APIでSpotifyのトラック情報取得、現在再生中楽曲取得、認証を提供。AWS Lambda + API Gateway構成でデプロイされる。
+
+## 開発コマンド
+
+### ローカル開発
+```bash
+make dev  # Docker Compose起動 + ドキュメント表示（http://localhost:10120/docs）
+```
+
+### テスト実行
+```bash
+make cdk-test  # CDKテスト実行（cd cdk && npm run test）
+```
+
+### CDK関連
+```bash
+cd cdk && npm run build    # TypeScriptコンパイル
+cd cdk && npm run test     # CDKテスト
+cd cdk && npm run cdk      # CDK CLI
+```
+
+## アーキテクチャ
+
+クリーンアーキテクチャベースの設計:
+
+### レイヤー構成
+- **router/**: FastAPIルーター（HTTP入出力層）
+- **usecase/**: ビジネスロジック
+- **service/**: サービス層（認証など）
+- **infrastructure/**: 外部システム接続（Spotify API、S3など）
+- **domain/**: ドメインモデル・リポジトリインターフェース
+- **interface/**: アプリケーションインターフェース
+
+### 主要エンドポイント
+- `/track/{track_id}`: トラック情報取得
+- `/current/playing`: 現在再生中楽曲取得
+- `/authorize`: Spotify認証
+
+### 依存関係
+- Python 3.11 + pipenv
+- FastAPI + Mangum（Lambda統合）
+- Spotipy（Spotify Web APIクライアント）
+- AWS CDK（TypeScript）でインフラ管理
+
+### インフラ構成
+- AWS Lambda（main.handler）
+- API Gateway
+- S3（トークン情報保存）
+- EventBridge（定期実行）
+
+## 新機能: Spotify監視システム
+
+### 概要
+24/7でSpotifyの再生履歴を監視し、S3に保存してObsidianに同期するシステム
+
+### アーキテクチャ
+1. **spotify-monitor.py** (EC2): 30秒間隔でSpotify APIを監視、S3にJSONL形式で保存
+2. **sync-from-s3.py** (ローカル): S3からダウンロードしてObsidian vaultにMarkdown生成
+
+### 主要スクリプト
+- `spotify-monitor.py`: EC2用監視スクリプト
+- `sync-from-s3.py`: ローカル同期スクリプト
+- `setup_ec2.md`: EC2セットアップ手順
+
+### 使用方法
+```bash
+# EC2での監視開始
+python3 spotify-monitor.py
+
+# ローカルでの同期実行
+python sync-from-s3.py /path/to/obsidian/vault --days 7
+```
+
+## 重要な実装パターン
+
+- 認証はヘッダ`access-token`で実行
+- Token管理はS3/ローカルリポジトリの実装切り替え可能
+- レスポンスオブジェクトはTranslatorパターンでドメインモデル変換
+- 環境変数は`util.environment.Environment`で管理
+- ログデータはJSONL形式でS3の`history/YYYY-MM-DD.jsonl`に保存

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ boto3 = "*"
 
 [dev-packages]
 uvicorn = "*"
+pytest = "*"
 
 [requires]
 python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7c857de61a8605694d743931198b22534bfb7dc53c4036257a8cd0f05113dfe9"
+            "sha256": "ecf68f31005f466eeb2aba9f9ce8188bf5af85e115e86db7457e71aa1c2bb769"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,132 +18,155 @@
     "default": {
         "anyio": {
             "hashes": [
-                "sha256:745843b39e829e108e518c489b31dc757de7d2131d53fac32bd8df268227bfee",
-                "sha256:e1875bb4b4e2de1669f4bc7869b6d3f54231cdced71605e6e64c9be77e3be50f"
+                "sha256:73c693b567b0c55130c104d0b43a9baf3aa6a31fc6110116509f27bf75e21ec0",
+                "sha256:dad2376a628f98eeca4881fc56cd06affd18f659b17a747d3ff0307ced94b1bb"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.2.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.12.0"
         },
         "boto3": {
             "hashes": [
-                "sha256:2c96f6a4e9ce2f4d31fc7ab47a2b3a1808063fa3837d7d8548eb2031380f7498",
-                "sha256:364f942d38da283031cde08c46c9282129fd9ebf96fa244f2709886c31ccd49a"
+                "sha256:8a2e345e96d5ceba755c55539c93f99705f403fbfdeef2e838eabdc56750828b",
+                "sha256:e0ee40f7102712452f6776af891c8f49b5ae9133bdaf22711d6f4a78963c2614"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==1.34.23"
+            "markers": "python_version >= '3.9'",
+            "version": "==1.42.17"
         },
         "botocore": {
             "hashes": [
-                "sha256:1980411306593bbc2b0cd9b8d1dcacbd418b758077b82f68b932070ad902cfe9",
-                "sha256:898fa169679782f396613f50a88b9b033845625c931275832063266110ea4297"
+                "sha256:a832e4c04e63141221480967e9e511363aa54d24c405935fccb913a18583c96b",
+                "sha256:d73fe22c8e1497e4d59ff7dc68eb05afac68a4a6457656811562285d6132bc04"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.34.23"
+            "markers": "python_version >= '3.9'",
+            "version": "==1.42.17"
         },
         "certifi": {
             "hashes": [
-                "sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
-                "sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"
+                "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b",
+                "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2023.11.17"
+            "markers": "python_version >= '3.7'",
+            "version": "==2025.11.12"
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027",
-                "sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087",
-                "sha256:0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786",
-                "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8",
-                "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09",
-                "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185",
-                "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574",
-                "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e",
-                "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519",
-                "sha256:2127566c664442652f024c837091890cb1942c30937add288223dc895793f898",
-                "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269",
-                "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3",
-                "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f",
-                "sha256:3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6",
-                "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8",
-                "sha256:37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a",
-                "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73",
-                "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc",
-                "sha256:42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714",
-                "sha256:45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2",
-                "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc",
-                "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce",
-                "sha256:4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d",
-                "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e",
-                "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6",
-                "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269",
-                "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96",
-                "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d",
-                "sha256:6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a",
-                "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4",
-                "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77",
-                "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d",
-                "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0",
-                "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed",
-                "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068",
-                "sha256:6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac",
-                "sha256:6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25",
-                "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8",
-                "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab",
-                "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26",
-                "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2",
-                "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db",
-                "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f",
-                "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5",
-                "sha256:86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99",
-                "sha256:87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c",
-                "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d",
-                "sha256:8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811",
-                "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa",
-                "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a",
-                "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03",
-                "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b",
-                "sha256:923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04",
-                "sha256:95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c",
-                "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001",
-                "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458",
-                "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389",
-                "sha256:a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99",
-                "sha256:a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985",
-                "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537",
-                "sha256:ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238",
-                "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f",
-                "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d",
-                "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796",
-                "sha256:b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a",
-                "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143",
-                "sha256:bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8",
-                "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c",
-                "sha256:c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5",
-                "sha256:c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5",
-                "sha256:c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711",
-                "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4",
-                "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6",
-                "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c",
-                "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7",
-                "sha256:db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4",
-                "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b",
-                "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae",
-                "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12",
-                "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c",
-                "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae",
-                "sha256:eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8",
-                "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887",
-                "sha256:eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b",
-                "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4",
-                "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f",
-                "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5",
-                "sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33",
-                "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519",
-                "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"
+                "sha256:027f6de494925c0ab2a55eab46ae5129951638a49a34d87f4c3eda90f696b4ad",
+                "sha256:077fbb858e903c73f6c9db43374fd213b0b6a778106bc7032446a8e8b5b38b93",
+                "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394",
+                "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89",
+                "sha256:0f04b14ffe5fdc8c4933862d8306109a2c51e0704acfa35d51598eb45a1e89fc",
+                "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86",
+                "sha256:194f08cbb32dc406d6e1aea671a68be0823673db2832b38405deba2fb0d88f63",
+                "sha256:1bee1e43c28aa63cb16e5c14e582580546b08e535299b8b6158a7c9c768a1f3d",
+                "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f",
+                "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8",
+                "sha256:244bfb999c71b35de57821b8ea746b24e863398194a4014e4c76adc2bbdfeff0",
+                "sha256:2677acec1a2f8ef614c6888b5b4ae4060cc184174a938ed4e8ef690e15d3e505",
+                "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161",
+                "sha256:2aaba3b0819274cc41757a1da876f810a3e4d7b6eb25699253a4effef9e8e4af",
+                "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152",
+                "sha256:2c9d3c380143a1fedbff95a312aa798578371eb29da42106a29019368a475318",
+                "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72",
+                "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4",
+                "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e",
+                "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3",
+                "sha256:44c2a8734b333e0578090c4cd6b16f275e07aa6614ca8715e6c038e865e70576",
+                "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c",
+                "sha256:4902828217069c3c5c71094537a8e623f5d097858ac6ca8252f7b4d10b7560f1",
+                "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8",
+                "sha256:4fe7859a4e3e8457458e2ff592f15ccb02f3da787fcd31e0183879c3ad4692a1",
+                "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2",
+                "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44",
+                "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26",
+                "sha256:5947809c8a2417be3267efc979c47d76a079758166f7d43ef5ae8e9f92751f88",
+                "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016",
+                "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede",
+                "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf",
+                "sha256:5cb4d72eea50c8868f5288b7f7f33ed276118325c1dfd3957089f6b519e1382a",
+                "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc",
+                "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0",
+                "sha256:64b55f9dce520635f018f907ff1b0df1fdc31f2795a922fb49dd14fbcdf48c84",
+                "sha256:6515f3182dbe4ea06ced2d9e8666d97b46ef4c75e326b79bb624110f122551db",
+                "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1",
+                "sha256:6aee717dcfead04c6eb1ce3bd29ac1e22663cdea57f943c87d1eab9a025438d7",
+                "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed",
+                "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8",
+                "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133",
+                "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e",
+                "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef",
+                "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14",
+                "sha256:778d2e08eda00f4256d7f672ca9fef386071c9202f5e4607920b86d7803387f2",
+                "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0",
+                "sha256:798d75d81754988d2565bff1b97ba5a44411867c0cf32b77a7e8f8d84796b10d",
+                "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828",
+                "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f",
+                "sha256:7c308f7e26e4363d79df40ca5b2be1c6ba9f02bdbccfed5abddb7859a6ce72cf",
+                "sha256:7fa17817dc5625de8a027cb8b26d9fefa3ea28c8253929b8d6649e705d2835b6",
+                "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328",
+                "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090",
+                "sha256:837c2ce8c5a65a2035be9b3569c684358dfbf109fd3b6969630a87535495ceaa",
+                "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381",
+                "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c",
+                "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb",
+                "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc",
+                "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a",
+                "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec",
+                "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc",
+                "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac",
+                "sha256:9cd98cdc06614a2f768d2b7286d66805f94c48cde050acdbbb7db2600ab3197e",
+                "sha256:9d1bb833febdff5c8927f922386db610b49db6e0d4f4ee29601d71e7c2694313",
+                "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569",
+                "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3",
+                "sha256:a61900df84c667873b292c3de315a786dd8dac506704dea57bc957bd31e22c7d",
+                "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525",
+                "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894",
+                "sha256:a8bf8d0f749c5757af2142fe7903a9df1d2e8aa3841559b2bad34b08d0e2bcf3",
+                "sha256:a9768c477b9d7bd54bc0c86dbaebdec6f03306675526c9927c0e8a04e8f94af9",
+                "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a",
+                "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9",
+                "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14",
+                "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25",
+                "sha256:b5d84d37db046c5ca74ee7bb47dd6cbc13f80665fdde3e8040bdd3fb015ecb50",
+                "sha256:b7cf1017d601aa35e6bb650b6ad28652c9cd78ee6caff19f3c28d03e1c80acbf",
+                "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1",
+                "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3",
+                "sha256:c4ef880e27901b6cc782f1b95f82da9313c0eb95c3af699103088fa0ac3ce9ac",
+                "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e",
+                "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815",
+                "sha256:cb01158d8b88ee68f15949894ccc6712278243d95f344770fa7593fa2d94410c",
+                "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6",
+                "sha256:cc00f04ed596e9dc0da42ed17ac5e596c6ccba999ba6bd92b0e0aef2f170f2d6",
+                "sha256:cd09d08005f958f370f539f186d10aec3377d55b9eeb0d796025d4886119d76e",
+                "sha256:cd4b7ca9984e5e7985c12bc60a6f173f3c958eae74f3ef6624bb6b26e2abbae4",
+                "sha256:ce8a0633f41a967713a59c4139d29110c07e826d131a316b50ce11b1d79b4f84",
+                "sha256:cead0978fc57397645f12578bfd2d5ea9138ea0fac82b2f63f7f7c6877986a69",
+                "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15",
+                "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191",
+                "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0",
+                "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897",
+                "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd",
+                "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2",
+                "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794",
+                "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d",
+                "sha256:e912091979546adf63357d7e2ccff9b44f026c075aeaf25a52d0e95ad2281074",
+                "sha256:eaabd426fe94daf8fd157c32e571c85cb12e66692f15516a83a03264b08d06c3",
+                "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224",
+                "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838",
+                "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a",
+                "sha256:f155a433c2ec037d4e8df17d18922c3a0d9b3232a396690f17175d2946f0218d",
+                "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d",
+                "sha256:f34be2938726fc13801220747472850852fe6b1ea75869a048d6f896838c896f",
+                "sha256:f820802628d2694cb7e56db99213f930856014862f3fd943d290ea8438d07ca8",
+                "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490",
+                "sha256:f8e160feb2aed042cd657a72acc0b481212ed28b1b9a95c0cee1621b524e1966",
+                "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9",
+                "sha256:fa09f53c465e532f4d3db095e0c55b615f010ad81803d383195b6b5ca6cbf5f3",
+                "sha256:faa3a41b2b66b6e50f84ae4a68c64fcd0c44355741c6374813a800cd6695db9e",
+                "sha256:fd44c878ea55ba351104cb93cc85e74916eb8fa440ca7903e57575e97394f608"
             ],
-            "markers": "python_full_version >= '3.7.0'",
-            "version": "==3.3.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==3.4.4"
         },
         "fastapi": {
             "hashes": [
@@ -156,11 +179,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca",
-                "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
+                "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea",
+                "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==3.6"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.11"
         },
         "jmespath": {
             "hashes": [
@@ -224,11 +247,11 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.2"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==2.9.0.post0"
         },
         "pyyaml": {
             "hashes": [
@@ -279,11 +302,11 @@
         },
         "redis": {
             "hashes": [
-                "sha256:0dab495cd5753069d3bc650a0dde8a8f9edde16fc5691b689a566eda58100d0f",
-                "sha256:ed4802971884ae19d640775ba3b03aa2e7bd5e8fb8dfaed2decce4d0fc48391f"
+                "sha256:23c52b208f92b56103e17c5d06bdc1a6c2c0b3106583985a76a18f83b265de2b",
+                "sha256:b1cc3cfa5a2cb9c2ab3ba700864fb0ad75617b41f01352ce5779dabf6d5f9c3c"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==5.0.1"
+            "markers": "python_version >= '3.10'",
+            "version": "==7.1.0"
         },
         "requests": {
             "hashes": [
@@ -296,36 +319,28 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:3cdb40f5cfa6966e812209d0994f2a4709b561c88e90cf00c2696d2df4e56b2e",
-                "sha256:d0c8bbf672d5eebbe4e57945e23b972d963f07d82f661cabf678a5c88831595b"
+                "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe",
+                "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==0.10.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==0.16.0"
         },
         "six": {
             "hashes": [
-                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+                "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+                "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.16.0"
-        },
-        "sniffio": {
-            "hashes": [
-                "sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101",
-                "sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.3.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.17.0"
         },
         "spotipy": {
             "hashes": [
-                "sha256:0dfafe08239daae6c16faa68f60b5775d40c4110725e1a7c545ad4c7fb66d4e8",
-                "sha256:6bf8b963c10d0a3e51037e4baf92e29732dee36b2a1f1b7dcc8cd5771e662a5b",
-                "sha256:da850fbf62faaa05912132d2886c293a5fbbe8350d0821e7208a6a2fdd6a0079"
+                "sha256:5ed45c044156ca5518997e2502b1f2c1e7336407cb1fb8fe112d144b4d5282c8",
+                "sha256:694bc9734d94171716257bf18eea9f1cb2ff8c581e59c74464137433830cf890"
             ],
             "index": "pypi",
-            "version": "==2.23.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==2.25.2"
         },
         "starlette": {
             "hashes": [
@@ -337,46 +352,87 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783",
-                "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"
+                "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+                "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.9.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.15.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84",
-                "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"
+                "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797",
+                "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.0.7"
+            "markers": "python_version >= '3.9'",
+            "version": "==2.6.2"
         }
     },
     "develop": {
         "click": {
             "hashes": [
-                "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
-                "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+                "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a",
+                "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==8.1.7"
+            "markers": "python_version >= '3.10'",
+            "version": "==8.3.1"
         },
         "h11": {
             "hashes": [
-                "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d",
-                "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"
+                "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1",
+                "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==0.14.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.16.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730",
+                "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==2.3.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484",
+                "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==25.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3",
+                "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.6.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887",
+                "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.19.2"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b",
+                "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==9.0.2"
         },
         "uvicorn": {
             "hashes": [
-                "sha256:48bfd350fce3c5c57af5fb4995fded8fb50da3b4feb543eb18ad7e0d54589602",
-                "sha256:cdb58ef6b8188c6c174994b2b1ba2150a9a8ae7ea5fb2f1b856b94a815d6071d"
+                "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea",
+                "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==0.26.0"
+            "markers": "python_version >= '3.10'",
+            "version": "==0.40.0"
         }
     }
 }

--- a/README_monitoring.md
+++ b/README_monitoring.md
@@ -1,0 +1,108 @@
+# Spotify リスニングヒストリー監視システム
+
+GitHub Issue #1 の対応として、24/7でSpotifyの再生履歴を自動監視し、ObsidianにMarkdown形式で同期するシステムを実装しました。
+
+## 機能概要
+
+1. **監視システム** (`spotify-monitor.py`): EC2上で24時間365日Spotify再生状況を監視
+2. **同期システム** (`sync-from-s3.py`): S3に保存されたログをローカルPCのObsidianに同期
+
+## アーキテクチャ
+
+```
+スマートフォン → Spotify API → EC2(monitoring) → S3 → ローカルPC → Obsidian
+```
+
+### データフロー
+1. スマートフォンで音楽再生
+2. EC2インスタンスがSpotify APIを30秒間隔で監視
+3. 再生情報をS3にJSONL形式で日別保存
+4. ローカルPCが起動時にS3から最新データを取得
+5. Obsidian vault内にMarkdownファイルとして保存
+
+## ファイル構成
+
+- `spotify-monitor.py`: EC2用監視スクリプト
+- `sync-from-s3.py`: ローカル同期スクリプト
+- `setup_ec2.md`: EC2セットアップ手順
+- `test_spotify_monitor.py`: 監視システムのテスト
+- `test_sync_from_s3.py`: 同期システムのテスト
+
+## セットアップ
+
+### 1. EC2での監視開始
+
+```bash
+# 環境変数設定
+export SPOTIPY_CLIENT_ID="your_spotify_client_id"
+export SPOTIPY_CLIENT_SECRET="your_spotify_client_secret" 
+export SPOTIPY_REDIRECT_URI="http://localhost:8080/callback"
+export SPOTIFY_ACCESS_TOKEN="your_access_token"
+
+# 監視開始
+python3 spotify-monitor.py
+```
+
+### 2. ローカルでの同期実行
+
+```bash
+# 最近7日間を同期
+python sync-from-s3.py /path/to/obsidian/vault --days 7
+
+# 特定期間を同期
+python sync-from-s3.py /path/to/obsidian/vault --start-date 2023-01-01 --end-date 2023-01-07
+
+# 既存ファイルを上書き
+python sync-from-s3.py /path/to/obsidian/vault --days 7 --overwrite
+```
+
+## 主要機能
+
+### 重複防止
+- 同一トラック・同一分内の記録は自動的に重複除去
+- 最低30秒間隔での記録で無駄なログを削減
+
+### エラーハンドリング
+- 一時的なネットワークエラーに対する自動リトライ
+- 連続エラー時の待機時間自動調整
+- 認証エラー時の適切な通知
+
+### ログ形式
+S3保存形式（JSONL）:
+```json
+{"track": {"id": "track_id", "name": "曲名", "artists": [{"name": "アーティスト名"}], "album": {"name": "アルバム名"}, "external_urls": {"spotify": "https://..."}}, "timestamp": "2023-01-01T12:00:00"}
+```
+
+Obsidian出力形式（Markdown）:
+```markdown
+# 2023-01-01 - 音楽リスニング履歴
+
+## 曲名 - アーティスト名
+
+- **アルバム**: アルバム名
+- **再生時刻**: 2023-01-01 12:00:00
+- **Spotify URL**: https://open.spotify.com/track/...
+```
+
+## テスト実行
+
+```bash
+# 全テスト実行
+pipenv run python -m pytest test_spotify_monitor.py test_sync_from_s3.py -v
+
+# 個別テスト
+pipenv run python -m pytest test_spotify_monitor.py -v
+pipenv run python -m pytest test_sync_from_s3.py -v
+```
+
+## 設定ファイル
+
+詳細な設定手順は以下を参照:
+- `setup_ec2.md`: EC2セットアップとsystemdサービス設定
+- `CLAUDE.md`: プロジェクト全体の設定と使用方法
+
+## 注意事項
+
+1. **アクセストークンの期限**: Spotifyアクセストークンは1時間で期限切れ
+2. **IAM権限**: EC2にS3への読み書き権限が必要
+3. **ネットワーク**: EC2からSpotify API (HTTPS/443) への接続が必要

--- a/setup_ec2.md
+++ b/setup_ec2.md
@@ -1,0 +1,115 @@
+# EC2セットアップ手順
+
+## 1. IAM権限設定
+
+EC2インスタンスに以下の権限が必要です：
+
+### IAM ロール作成
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Resource": "arn:aws:s3:::spotify-api-bucket-koboriakira/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::spotify-api-bucket-koboriakira"
+    }
+  ]
+}
+```
+
+## 2. 環境変数設定
+
+EC2インスタンスで以下の環境変数を設定：
+
+```bash
+export SPOTIPY_CLIENT_ID="your_spotify_client_id"
+export SPOTIPY_CLIENT_SECRET="your_spotify_client_secret"
+export SPOTIPY_REDIRECT_URI="http://localhost:8080/callback"
+export SPOTIFY_ACCESS_TOKEN="your_access_token"
+```
+
+## 3. パッケージインストール
+
+```bash
+# Python3とpipのインストール
+sudo yum update -y
+sudo yum install -y python3 python3-pip
+
+# 必要なパッケージのインストール
+pip3 install spotipy boto3 requests
+```
+
+## 4. スクリプト配置
+
+```bash
+# spotify-monitor.pyを配置
+scp spotify-monitor.py ec2-user@your-instance:/home/ec2-user/
+```
+
+## 5. systemdサービス設定
+
+`/etc/systemd/system/spotify-monitor.service`を作成：
+
+```ini
+[Unit]
+Description=Spotify Monitor Service
+After=network.target
+
+[Service]
+Type=simple
+User=ec2-user
+WorkingDirectory=/home/ec2-user
+ExecStart=/usr/bin/python3 /home/ec2-user/spotify-monitor.py
+Environment=SPOTIPY_CLIENT_ID=your_client_id
+Environment=SPOTIPY_CLIENT_SECRET=your_client_secret
+Environment=SPOTIPY_REDIRECT_URI=http://localhost:8080/callback
+Environment=SPOTIFY_ACCESS_TOKEN=your_access_token
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## 6. サービス開始
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable spotify-monitor.service
+sudo systemctl start spotify-monitor.service
+
+# ステータス確認
+sudo systemctl status spotify-monitor.service
+```
+
+## 7. ログ確認
+
+```bash
+# サービスログの確認
+sudo journalctl -u spotify-monitor.service -f
+
+# S3への保存状況確認
+aws s3 ls s3://spotify-api-bucket-koboriakira/history/
+```
+
+## トラブルシューティング
+
+### アクセストークンの更新
+Spotifyアクセストークンは1時間で期限切れになるため、定期的な更新が必要です。
+既存のトークン更新機能を活用して自動更新を実装してください。
+
+### エラー対応
+- **権限エラー**: IAM権限を再確認
+- **ネットワークエラー**: セキュリティグループでHTTPS(443)を許可
+- **S3エラー**: バケット名とリージョンを確認

--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -1,0 +1,163 @@
+import json
+import time
+import boto3
+from datetime import datetime, timedelta
+from typing import Optional
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), 'spotify_api'))
+
+from util.environment import Environment
+from interface import track
+from custom_logger import get_logger
+
+logger = get_logger(__name__)
+
+BUCKET_NAME = "spotify-api-bucket-koboriakira"
+MONITOR_INTERVAL = 30  # 30秒間隔で監視
+
+
+class HistoryLog:
+    def __init__(self, track_data: dict, timestamp: datetime):
+        self.track_data = track_data
+        self.timestamp = timestamp
+    
+    def to_jsonl(self) -> str:
+        return json.dumps({
+            "track": self.track_data,
+            "timestamp": self.timestamp.isoformat()
+        })
+
+
+class SpotifyMonitor:
+    def __init__(self, access_token: str):
+        self.access_token = access_token
+        self.s3_client = boto3.client('s3')
+        self.last_track_id = None
+        self.current_track_start_time = None
+    
+    def get_current_track(self):
+        """現在再生中のトラックを取得"""
+        Environment.valid_access_token(self.access_token)
+        return track.get_current_playing()
+    
+    def save_to_s3(self, jsonl_data: str, date_str: str):
+        """S3にJSONLデータを保存"""
+        key = f"history/{date_str}.jsonl"
+        try:
+            # 既存のファイルがあるかチェック
+            try:
+                response = self.s3_client.get_object(Bucket=BUCKET_NAME, Key=key)
+                existing_data = response['Body'].read().decode('utf-8')
+                jsonl_data = existing_data + jsonl_data
+            except self.s3_client.exceptions.NoSuchKey:
+                # ファイルが存在しない場合は新規作成
+                logger.info(f"新しいファイルを作成します: {key}")
+            
+            self.s3_client.put_object(
+                Bucket=BUCKET_NAME,
+                Key=key,
+                Body=jsonl_data
+            )
+            logger.info(f"S3に保存しました: {key}")
+        except Exception as e:
+            logger.error(f"S3への保存に失敗しました: {e}")
+            raise
+    
+    def create_track_data(self, track):
+        """トラックデータをログ形式に変換"""
+        return {
+            "id": track.id,
+            "name": track.name,
+            "artists": track.artists,
+            "album": track.album,
+            "duration_ms": track.duration_ms,
+            "external_urls": track.external_urls,
+            "uri": track.uri
+        }
+    
+    def should_log_track(self, current_track) -> bool:
+        """トラックをログに記録すべきかを判定（重複防止機能含む）"""
+        if current_track is None:
+            return False
+        
+        # 新しいトラックの場合
+        if self.last_track_id != current_track.id:
+            self.last_track_id = current_track.id
+            self.current_track_start_time = datetime.now()
+            logger.info(f"新しいトラックを検出: {current_track.name}")
+            return True
+        
+        # 同じトラックが継続して再生されている場合の重複防止
+        if self.current_track_start_time:
+            elapsed = datetime.now() - self.current_track_start_time
+            # 最低30秒間隔でのログ記録（重複防止）
+            if elapsed >= timedelta(seconds=30):
+                logger.info(f"継続再生トラック記録: {current_track.name} ({elapsed.total_seconds():.1f}秒経過)")
+                self.current_track_start_time = datetime.now()
+                return True
+        
+        return False
+    
+    def run(self):
+        """監視を開始（エラーハンドリング強化）"""
+        logger.info("Spotify監視を開始します")
+        consecutive_errors = 0
+        max_consecutive_errors = 5
+        
+        while True:
+            try:
+                current_track = self.get_current_track()
+                
+                if self.should_log_track(current_track):
+                    track_data = self.create_track_data(current_track)
+                    timestamp = datetime.now()
+                    history_log = HistoryLog(track_data, timestamp)
+                    
+                    # 日付ベースでファイル分割
+                    date_str = timestamp.strftime("%Y-%m-%d")
+                    jsonl_line = history_log.to_jsonl() + "\n"
+                    
+                    self.save_to_s3(jsonl_line, date_str)
+                    logger.info(f"トラックをログに記録: {current_track.name} - {current_track.artists[0]['name']}")
+                
+                # 成功した場合はエラーカウンタをリセット
+                consecutive_errors = 0
+                time.sleep(MONITOR_INTERVAL)
+                
+            except KeyboardInterrupt:
+                logger.info("監視を停止します")
+                break
+            except Exception as e:
+                consecutive_errors += 1
+                logger.error(f"監視中にエラーが発生しました ({consecutive_errors}/{max_consecutive_errors}): {e}")
+                
+                # 連続エラーが多すぎる場合は長めに待機
+                if consecutive_errors >= max_consecutive_errors:
+                    logger.warning(f"{max_consecutive_errors}回連続でエラーが発生しました。5分間待機します。")
+                    time.sleep(300)  # 5分間待機
+                    consecutive_errors = 0  # リセット
+                else:
+                    time.sleep(MONITOR_INTERVAL)
+                    
+                # 致命的エラーの場合は再起動を促す
+                if "authentication" in str(e).lower() or "unauthorized" in str(e).lower():
+                    logger.critical("認証エラーが発生しました。アクセストークンを確認してください。")
+                    break
+
+
+def main():
+    import os
+    
+    # アクセストークンを環境変数から取得
+    access_token = os.getenv("SPOTIFY_ACCESS_TOKEN")
+    if not access_token:
+        logger.error("SPOTIFY_ACCESS_TOKEN環境変数が設定されていません")
+        return
+    
+    monitor = SpotifyMonitor(access_token)
+    monitor.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/sync_from_s3.py
+++ b/sync_from_s3.py
@@ -1,0 +1,200 @@
+import json
+import os
+import boto3
+from datetime import datetime, date, timedelta
+from typing import List, Dict, Any
+import logging
+
+# ロギング設定
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+BUCKET_NAME = "spotify-api-bucket-koboriakira"
+
+
+class MarkdownGenerator:
+    @staticmethod
+    def generate_for_track(track_data: Dict[str, Any], timestamp: datetime) -> str:
+        """1つのトラックに対するMarkdownを生成"""
+        artist_names = ", ".join([artist["name"] for artist in track_data["artists"]])
+        album_name = track_data["album"]["name"]
+        spotify_url = track_data["external_urls"]["spotify"]
+        
+        return f"""## {track_data["name"]} - {artist_names}
+
+- **アルバム**: {album_name}
+- **再生時刻**: {timestamp.strftime("%Y-%m-%d %H:%M:%S")}
+- **Spotify URL**: {spotify_url}
+
+---
+"""
+    
+    @staticmethod
+    def generate_daily_summary(tracks: List[Dict[str, Any]], target_date: date) -> str:
+        """1日分の全トラックのMarkdownサマリーを生成"""
+        header = f"# {target_date.strftime('%Y-%m-%d')} - 音楽リスニング履歴\n\n"
+        header += f"合計再生回数: {len(tracks)}曲\n\n"
+        
+        content = header
+        
+        for track_entry in tracks:
+            track_data = track_entry["track"]
+            timestamp = datetime.fromisoformat(track_entry["timestamp"])
+            content += MarkdownGenerator.generate_for_track(track_data, timestamp)
+        
+        return content
+
+
+class ObsidianSyncer:
+    def __init__(self, obsidian_vault_path: str):
+        self.obsidian_vault_path = obsidian_vault_path
+        self.s3_client = boto3.client('s3')
+        self.music_folder = os.path.join(obsidian_vault_path, "music")
+        
+        # musicフォルダが存在しない場合は作成
+        os.makedirs(self.music_folder, exist_ok=True)
+    
+    def download_from_s3(self, date_str: str) -> List[Dict[str, Any]]:
+        """S3から指定日のJSONLファイルをダウンロードして解析"""
+        key = f"history/{date_str}.jsonl"
+        
+        try:
+            response = self.s3_client.get_object(Bucket=BUCKET_NAME, Key=key)
+            content = response['Body'].read().decode('utf-8')
+            
+            # JSONLを行ごとに解析
+            tracks = []
+            for line in content.strip().split('\n'):
+                if line:
+                    tracks.append(json.loads(line))
+            
+            logger.info(f"S3から{len(tracks)}件のトラック情報を取得しました: {date_str}")
+            return tracks
+            
+        except self.s3_client.exceptions.NoSuchKey:
+            logger.info(f"S3にファイルが見つかりません: {key}")
+            return []
+        except Exception as e:
+            logger.error(f"S3からのダウンロードエラー: {e}")
+            raise
+    
+    def save_to_obsidian(self, tracks: List[Dict[str, Any]], target_date: date):
+        """トラック情報をObsidian形式のMarkdownファイルとして保存（重複除去付き）"""
+        if not tracks:
+            logger.info(f"保存するトラック情報がありません: {target_date}")
+            return
+        
+        # 重複除去（同一トラックID + 同一時刻の除去）
+        unique_tracks = self.remove_duplicates(tracks)
+        logger.info(f"重複除去: {len(tracks)}件 -> {len(unique_tracks)}件")
+        
+        # Markdownコンテンツ生成
+        markdown_content = MarkdownGenerator.generate_daily_summary(unique_tracks, target_date)
+        
+        # ファイルパス生成
+        filename = f"{target_date.strftime('%Y-%m-%d')}.md"
+        file_path = os.path.join(self.music_folder, filename)
+        
+        # ファイル保存
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write(markdown_content)
+        
+        logger.info(f"Obsidianファイルを保存しました: {file_path}")
+    
+    def remove_duplicates(self, tracks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """重複するトラック記録を除去"""
+        seen = set()
+        unique_tracks = []
+        
+        for track_entry in tracks:
+            # トラックIDとタイムスタンプの分（秒以下は無視）で重複判定
+            track_id = track_entry["track"]["id"]
+            timestamp_str = track_entry["timestamp"]
+            timestamp_minute = timestamp_str[:16]  # YYYY-MM-DDTHH:MM部分のみ
+            
+            key = (track_id, timestamp_minute)
+            
+            if key not in seen:
+                seen.add(key)
+                unique_tracks.append(track_entry)
+            else:
+                logger.debug(f"重複を除去: {track_entry['track']['name']} at {timestamp_str}")
+        
+        return unique_tracks
+    
+    def check_existing_files(self) -> List[date]:
+        """既存のObsidianファイルの日付リストを取得"""
+        existing_dates = []
+        
+        if not os.path.exists(self.music_folder):
+            return existing_dates
+        
+        for filename in os.listdir(self.music_folder):
+            if filename.endswith('.md') and len(filename) == 13:  # YYYY-MM-DD.md
+                try:
+                    date_str = filename[:-3]  # .mdを除去
+                    file_date = datetime.strptime(date_str, '%Y-%m-%d').date()
+                    existing_dates.append(file_date)
+                except ValueError:
+                    continue
+        
+        return sorted(existing_dates)
+    
+    def sync_date_range(self, start_date: date, end_date: date, overwrite: bool = False):
+        """指定された日付範囲を同期"""
+        current_date = start_date
+        
+        while current_date <= end_date:
+            date_str = current_date.strftime('%Y-%m-%d')
+            file_path = os.path.join(self.music_folder, f"{date_str}.md")
+            
+            # 既存ファイルがある場合の処理
+            if os.path.exists(file_path) and not overwrite:
+                logger.info(f"ファイルが既に存在します（スキップ）: {date_str}")
+                current_date += timedelta(days=1)
+                continue
+            
+            # S3からダウンロード
+            tracks = self.download_from_s3(date_str)
+            
+            # Obsidianに保存
+            if tracks:
+                self.save_to_obsidian(tracks, current_date)
+            
+            current_date += timedelta(days=1)
+    
+    def sync_recent_days(self, days: int = 7, overwrite: bool = False):
+        """最近の指定日数を同期"""
+        end_date = date.today()
+        start_date = end_date - timedelta(days=days-1)
+        
+        logger.info(f"最近{days}日間を同期します: {start_date} 〜 {end_date}")
+        self.sync_date_range(start_date, end_date, overwrite)
+
+
+def main():
+    import argparse
+    
+    parser = argparse.ArgumentParser(description='Spotify履歴をS3からObsidianに同期')
+    parser.add_argument('vault_path', help='Obsidian vaultのパス')
+    parser.add_argument('--days', type=int, default=7, help='同期する日数（デフォルト: 7日）')
+    parser.add_argument('--start-date', help='開始日（YYYY-MM-DD形式）')
+    parser.add_argument('--end-date', help='終了日（YYYY-MM-DD形式）')
+    parser.add_argument('--overwrite', action='store_true', help='既存ファイルを上書き')
+    
+    args = parser.parse_args()
+    
+    syncer = ObsidianSyncer(args.vault_path)
+    
+    if args.start_date and args.end_date:
+        # 日付範囲指定での同期
+        start_date = datetime.strptime(args.start_date, '%Y-%m-%d').date()
+        end_date = datetime.strptime(args.end_date, '%Y-%m-%d').date()
+        syncer.sync_date_range(start_date, end_date, args.overwrite)
+    else:
+        # 最近の日数での同期
+        syncer.sync_recent_days(args.days, args.overwrite)
+
+
+if __name__ == "__main__":
+    main()

--- a/test_spotify_monitor.py
+++ b/test_spotify_monitor.py
@@ -1,0 +1,120 @@
+import pytest
+import json
+from datetime import datetime
+from unittest.mock import Mock, patch, MagicMock
+
+# 環境変数をモック
+with patch.dict('os.environ', {
+    'SPOTIPY_CLIENT_ID': 'test_client_id',
+    'SPOTIPY_CLIENT_SECRET': 'test_client_secret',
+    'SPOTIPY_REDIRECT_URI': 'http://localhost:8080/callback',
+    'ACCESS_TOKEN': 'test_access_token'
+}):
+    from spotify_monitor import SpotifyMonitor, HistoryLog
+
+
+class TestHistoryLog:
+    def test_history_log_creation(self):
+        track_data = {
+            "id": "test_id",
+            "name": "Test Song",
+            "artists": [{"name": "Test Artist"}],
+            "album": {"name": "Test Album"},
+            "external_urls": {"spotify": "https://open.spotify.com/track/test_id"}
+        }
+        timestamp = datetime.now()
+        
+        log = HistoryLog(track_data, timestamp)
+        
+        assert log.track_data == track_data
+        assert log.timestamp == timestamp
+    
+    def test_to_jsonl(self):
+        track_data = {
+            "id": "test_id",
+            "name": "Test Song",
+            "artists": [{"name": "Test Artist"}],
+            "album": {"name": "Test Album"},
+            "external_urls": {"spotify": "https://open.spotify.com/track/test_id"}
+        }
+        timestamp = datetime(2023, 1, 1, 12, 0, 0)
+        
+        log = HistoryLog(track_data, timestamp)
+        jsonl = log.to_jsonl()
+        
+        expected = {
+            "track": track_data,
+            "timestamp": "2023-01-01T12:00:00"
+        }
+        assert json.loads(jsonl) == expected
+
+
+class TestSpotifyMonitor:
+    @patch.dict('os.environ', {
+        'SPOTIPY_CLIENT_ID': 'test_client_id',
+        'SPOTIPY_CLIENT_SECRET': 'test_client_secret',
+        'SPOTIPY_REDIRECT_URI': 'http://localhost:8080/callback',
+        'ACCESS_TOKEN': 'test_access_token'
+    })
+    @patch('spotify_monitor.Environment.valid_access_token')
+    @patch('spotify_monitor.track.get_current_playing')
+    def test_get_current_track(self, mock_get_current, mock_valid_token):
+        mock_track = Mock()
+        mock_track.id = "test_id"
+        mock_track.name = "Test Song"
+        mock_track.artists = [{"name": "Test Artist"}]
+        mock_track.album = {"name": "Test Album"}
+        mock_track.external_urls = {"spotify": "https://open.spotify.com/track/test_id"}
+        mock_get_current.return_value = mock_track
+        
+        monitor = SpotifyMonitor("test_token")
+        result = monitor.get_current_track()
+        
+        assert result == mock_track
+        mock_valid_token.assert_called_once_with("test_token")
+        mock_get_current.assert_called_once()
+    
+    @patch.dict('os.environ', {
+        'SPOTIPY_CLIENT_ID': 'test_client_id',
+        'SPOTIPY_CLIENT_SECRET': 'test_client_secret',
+        'SPOTIPY_REDIRECT_URI': 'http://localhost:8080/callback',
+        'ACCESS_TOKEN': 'test_access_token'
+    })
+    @patch('spotify_monitor.Environment.valid_access_token')
+    @patch('spotify_monitor.track.get_current_playing')
+    def test_get_current_track_none(self, mock_get_current, mock_valid_token):
+        mock_get_current.return_value = None
+        
+        monitor = SpotifyMonitor("test_token")
+        result = monitor.get_current_track()
+        
+        assert result is None
+    
+    @patch.dict('os.environ', {
+        'SPOTIPY_CLIENT_ID': 'test_client_id',
+        'SPOTIPY_CLIENT_SECRET': 'test_client_secret',
+        'SPOTIPY_REDIRECT_URI': 'http://localhost:8080/callback',
+        'ACCESS_TOKEN': 'test_access_token'
+    })
+    @patch('boto3.client')
+    def test_save_to_s3_new_file(self, mock_boto3):
+        """新規ファイル作成のテスト"""
+        mock_s3 = MagicMock()
+        mock_boto3.return_value = mock_s3
+        
+        # ファイルが存在しない場合をシミュレート
+        mock_s3.exceptions.NoSuchKey = type('NoSuchKey', (Exception,), {})
+        mock_s3.get_object.side_effect = mock_s3.exceptions.NoSuchKey()
+        
+        monitor = SpotifyMonitor("test_token")
+        
+        # テスト用のJSONLデータ
+        jsonl_data = '{"track": {"id": "test"}, "timestamp": "2023-01-01T12:00:00"}\n'
+        
+        monitor.save_to_s3(jsonl_data, "2023-01-01")
+        
+        mock_s3.put_object.assert_called_once_with(
+            Bucket="spotify-api-bucket-koboriakira",
+            Key="history/2023-01-01.jsonl",
+            Body=jsonl_data
+        )

--- a/test_sync_from_s3.py
+++ b/test_sync_from_s3.py
@@ -1,0 +1,155 @@
+import pytest
+import json
+import tempfile
+import os
+from datetime import datetime, date
+from unittest.mock import Mock, patch, MagicMock
+from sync_from_s3 import ObsidianSyncer, MarkdownGenerator
+
+
+class TestMarkdownGenerator:
+    def test_generate_for_track(self):
+        track_data = {
+            "id": "test_id",
+            "name": "Test Song",
+            "artists": [{"name": "Test Artist"}],
+            "album": {"name": "Test Album"},
+            "external_urls": {"spotify": "https://open.spotify.com/track/test_id"}
+        }
+        timestamp = datetime(2023, 1, 1, 12, 0, 0)
+        
+        result = MarkdownGenerator.generate_for_track(track_data, timestamp)
+        
+        expected = """## Test Song - Test Artist
+
+- **アルバム**: Test Album
+- **再生時刻**: 2023-01-01 12:00:00
+- **Spotify URL**: https://open.spotify.com/track/test_id
+
+---
+"""
+        assert result == expected
+    
+    def test_generate_daily_summary(self):
+        tracks = [
+            {
+                "track": {
+                    "name": "Song 1",
+                    "artists": [{"name": "Artist 1"}],
+                    "album": {"name": "Album 1"},
+                    "external_urls": {"spotify": "https://open.spotify.com/track/1"}
+                },
+                "timestamp": "2023-01-01T12:00:00"
+            },
+            {
+                "track": {
+                    "name": "Song 2", 
+                    "artists": [{"name": "Artist 2"}],
+                    "album": {"name": "Album 2"},
+                    "external_urls": {"spotify": "https://open.spotify.com/track/2"}
+                },
+                "timestamp": "2023-01-01T13:00:00"
+            }
+        ]
+        
+        result = MarkdownGenerator.generate_daily_summary(tracks, date(2023, 1, 1))
+        
+        assert "# 2023-01-01 - 音楽リスニング履歴" in result
+        assert "## Song 1 - Artist 1" in result
+        assert "## Song 2 - Artist 2" in result
+
+
+class TestObsidianSyncer:
+    @patch('boto3.client')
+    def test_download_from_s3_success(self, mock_boto3):
+        mock_s3 = MagicMock()
+        mock_boto3.return_value = mock_s3
+        
+        # S3からのレスポンスをモック
+        mock_response = {
+            'Body': Mock()
+        }
+        mock_response['Body'].read.return_value = b'{"track": {"id": "test"}, "timestamp": "2023-01-01T12:00:00"}\n'
+        mock_s3.get_object.return_value = mock_response
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            syncer = ObsidianSyncer(temp_dir)
+            result = syncer.download_from_s3("2023-01-01")
+            
+            expected = [{"track": {"id": "test"}, "timestamp": "2023-01-01T12:00:00"}]
+            assert result == expected
+            
+            mock_s3.get_object.assert_called_once_with(
+                Bucket="spotify-api-bucket-koboriakira",
+                Key="history/2023-01-01.jsonl"
+            )
+    
+    @patch('boto3.client')
+    def test_download_from_s3_not_found(self, mock_boto3):
+        mock_s3 = MagicMock()
+        mock_boto3.return_value = mock_s3
+        
+        # ファイルが存在しない場合をシミュレート
+        mock_s3.exceptions.NoSuchKey = type('NoSuchKey', (Exception,), {})
+        mock_s3.get_object.side_effect = mock_s3.exceptions.NoSuchKey()
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            syncer = ObsidianSyncer(temp_dir)
+            result = syncer.download_from_s3("2023-01-01")
+            
+            assert result == []
+    
+    def test_save_to_obsidian(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            syncer = ObsidianSyncer(temp_dir)
+            
+            tracks = [
+                {
+                    "track": {
+                        "id": "test_id",
+                        "name": "Test Song",
+                        "artists": [{"name": "Test Artist"}],
+                        "album": {"name": "Test Album"},
+                        "external_urls": {"spotify": "https://open.spotify.com/track/test"}
+                    },
+                    "timestamp": "2023-01-01T12:00:00"
+                }
+            ]
+            
+            syncer.save_to_obsidian(tracks, date(2023, 1, 1))
+            
+            # ファイルが作成されたことを確認
+            expected_path = os.path.join(temp_dir, "music", "2023-01-01.md")
+            assert os.path.exists(expected_path)
+            
+            # ファイル内容を確認
+            with open(expected_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+                assert "Test Song - Test Artist" in content
+    
+    def test_remove_duplicates(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            syncer = ObsidianSyncer(temp_dir)
+            
+            # 重複を含むトラックデータ
+            tracks = [
+                {
+                    "track": {"id": "track1", "name": "Song 1", "artists": [{"name": "Artist 1"}]},
+                    "timestamp": "2023-01-01T12:00:00"
+                },
+                {
+                    "track": {"id": "track1", "name": "Song 1", "artists": [{"name": "Artist 1"}]},
+                    "timestamp": "2023-01-01T12:00:30"  # 同じ分内の重複
+                },
+                {
+                    "track": {"id": "track2", "name": "Song 2", "artists": [{"name": "Artist 2"}]},
+                    "timestamp": "2023-01-01T12:01:00"
+                }
+            ]
+            
+            result = syncer.remove_duplicates(tracks)
+            
+            # 重複が除去されて2件になることを確認
+            assert len(result) == 2
+            assert result[0]["track"]["id"] == "track1"
+            assert result[1]["track"]["id"] == "track2"


### PR DESCRIPTION
GitHub Issue #1の対応として、24/7でSpotifyの再生履歴を監視し、Obsidianに同期するシステムを実装。

## 主な機能
- spotify-monitor.py: EC2での24/7 Spotify API監視、S3にJSONL保存
- sync-from-s3.py: S3からローカルObsidianへの同期
- 重複防止機能とエラーハンドリング強化
- 包括的なテストカバレッジ

## アーキテクチャ
スマートフォン → Spotify API → EC2 → S3 → ローカルPC → Obsidian

🤖 Generated with [Claude Code](https://claude.ai/code)