### PR TITLE
Fix CDK Deploy: add required environment parameter

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           workdir: cdk
           aws-role: ${{ secrets.AWS_ROLE }}
+          environment: production
         env:
           SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
           SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}


### PR DESCRIPTION
The deploy_cdk action requires an environment parameter that was
missing, causing the deployment to fail.