### PR TITLE
Fix deploy workflow: remove invalid ref for push events

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v4
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Generate requirements.txt from uv.lock
+        run: uv export --no-hashes --no-dev --no-emit-project -o requirements.txt
+
       - name: Generate Lambda Layer
         uses: koboriakira/gh-actions/aws/generate-lambda-layer@main
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Generate Lambda Layer
         uses: koboriakira/gh-actions/aws/generate-lambda-layer@main


### PR DESCRIPTION
The github.head_ref variable is only available for pull_request events,
not for push events. Removing it allows the default checkout behavior
which correctly checks out the commit that triggered the workflow.